### PR TITLE
Fixed groff error when using "aws help".

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && \
     ca-certificates \
     curl \
     gnupg2 \
-    software-properties-common
+    software-properties-common \
+    groff
     
 
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ The follwoing tool will be provices by this shell
 ## How to build and push
 
     docker login
-    docker build -t kochp/aws-automation-bash:v1.3 .
-    docker push kochp/aws-automation-bash:v1.3
+    docker build -t kochp/ansible-aws-bash:v1.3 .
+    docker push kochp/ansible-aws-bash:v1.3
 
 ## Dependencies
 


### PR DESCRIPTION
Groff was missing on the system. Was fixed by adding it to apt-get.